### PR TITLE
for Luismahou/grunt-hashres#52 to fix dropping the url parameters

### DIFF
--- a/tasks/hashresHelper.js
+++ b/tasks/hashresHelper.js
@@ -60,8 +60,8 @@ exports.hashAndSub = function(grunt, options) {
         grunt.log.write(src + ' ').ok(renamed);
       });
 
-      // sort by length 
-      // It is very useful when we have bar.js and foo-bar.js 
+      // sort by length
+      // It is very useful when we have bar.js and foo-bar.js
       // @crodas
       var files = [];
       for (var name in nameToHashedName) {
@@ -77,12 +77,12 @@ exports.hashAndSub = function(grunt, options) {
       grunt.file.expand(f.dest).forEach(function(f) {
         var destContents = fs.readFileSync(f, encoding);
         files.forEach(function(value) {
-          grunt.log.debug('Substituting ' + value[0] + ' by ' + value[1])
-          destContents = destContents.replace(new RegExp(utils.preg_quote(value[0])+"(\\?[0-9a-z]+)?", "g"), value[1]);
+          grunt.log.debug('Substituting ' + value[0] + ' by ' + value[1]);
+          destContents = destContents.replace(new RegExp(utils.preg_quote(value[0])+"(\\?[0-9a-z]+)?", "g"), value[1]+"$1");
 
-          grunt.log.debug('Substituting ' + nameToNameSearch[value[0]] + ' by ' + value[1])
+          grunt.log.debug('Substituting ' + nameToNameSearch[value[0]] + ' by ' + value[1]);
           destContents = destContents.replace(
-                new RegExp(nameToNameSearch[value[0]], "g"), 
+                new RegExp(nameToNameSearch[value[0]], "g"),
                 value[1]
             );
         });

--- a/test/fixtures/withurlparams/Gruntfile.js
+++ b/test/fixtures/withurlparams/Gruntfile.js
@@ -1,0 +1,24 @@
+/*
+ * grunt-hashres
+ * https://github.com/luismahou/grunt-hashres
+ *
+ * Copyright (c) 2015 Darrel Herbst
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    hashres: {
+      withUrlParams: {
+        src : ['myscripts.js', 'test.js'],
+        dest: ['*.html']
+      }
+    }
+  });
+
+  grunt.loadTasks('../../../tasks');
+
+};

--- a/test/fixtures/withurlparams/index.html
+++ b/test/fixtures/withurlparams/index.html
@@ -1,0 +1,6 @@
+<html>
+  <head>
+    <script type="text/javascript" src="myscripts.js?v=4.2.0"></script>
+    <script type="text/javascript" src="test.js"></script>
+  </head>
+</html>

--- a/test/fixtures/withurlparams/myscripts.js
+++ b/test/fixtures/withurlparams/myscripts.js
@@ -1,0 +1,3 @@
+(function() {
+  // Nothing to do
+})

--- a/test/fixtures/withurlparams/test.js
+++ b/test/fixtures/withurlparams/test.js
@@ -1,0 +1,3 @@
+(function() {
+  // Nothing to do
+})

--- a/test/hashres.spec.js
+++ b/test/hashres.spec.js
@@ -42,6 +42,7 @@ var pathWithDefaultOptions    = 'temp/hashres/options/with-default-options';
 var pathSamePostFix           = 'temp/hashres/same-postfix';
 var pathWithSpecialCharacters = 'temp/hashres/options/with-special-characters';
 var pathOverridingHashedFiles = 'temp/hashres/overriding';
+var pathWithUrlParams         = 'temp/hashres/withurlparams';
 
 vows.describe('hashres').addBatch({
   'with custom options': {
@@ -134,6 +135,22 @@ vows.describe('hashres').addBatch({
       // index.html has been updated with the second version
       var html = grunt.file.read(pathOverridingHashedFiles + '/index.html');
       assert(html.indexOf('js/cab5c571.script.cache.js') !== -1);
+    }
+  },
+  'replacing with url parameters': {
+    topic: function() {
+      runCommand(
+        '../../../node_modules/grunt-cli/bin/./grunt hashres:withUrlParams',
+        { cwd: pathWithUrlParams },
+        this.callback);
+    },
+    'hashes resources with a quetsion mark at the end and does not chop off the question mark': function() {
+      assert(grunt.file.exists(pathWithUrlParams + '/8e99730f.myscripts.cache.js'));
+      assert(grunt.file.exists(pathWithUrlParams + '/8e99730f.test.cache.js'));
+      // index.html has been updated with the second version
+      var html = grunt.file.read(pathWithUrlParams + '/index.html');
+      assert(html.indexOf('8e99730f.myscripts.cache.js?v=4.2.0') !== -1);
+      assert(html.indexOf('8e99730f.test.cache.js') !== -1);
     }
   }
 }).export(module);


### PR DESCRIPTION
This fixes hashres from dropping url parameters.

```
$ npm install
$ grunt
Running "jshint:all" (jshint) task
>> 7 files lint free.

Running "vows:all" (vows) task
process finished: 0
·callback finished
Child Process STDERR: 
process finished: 0
·callback finished
process finished: 0
·callback finished
process finished: 0
·callback finished
Child Process STDERR: 
process finished: 0
·callback finished
process finished: 0
· callback finished
Child Process STDERR: 
./temp/helper/simple/myscripts.js >> 5a7a5b61.myscripts.cache.js
·./temp/helper/subfolders/scripts/myscripts1.js >> 5a7a5b61-myscripts1.js
./temp/helper/subfolders/scripts/myscripts2.js >> 5a7a5b61-myscripts2.js
./temp/helper/subfolders/styles/mystyles1.css >> 3b97b071-mystyles1.css
./temp/helper/subfolders/styles/mystyles2.css >> 3b97b071-mystyles2.css
· ······  
  ✓ OK » 14 honored (1.144s) 
  
Done, without errors.
```